### PR TITLE
fix: DropNanInplace

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,12 +6,12 @@ import (
 )
 
 // Routes Routes
-type Routes struct {
-}
+type Routes struct{}
 
 func (r *Routes) helloWorld() map[string]string {
 	return map[string]string{"hello": "world"}
 }
+
 func (r *Routes) RouteIndex(c *apiserver.Context) {
 	logging.Info("coming in here")
 	a := r.helloWorld()

--- a/numf/nan.go
+++ b/numf/nan.go
@@ -50,7 +50,6 @@ func NanSlice(size int) (nanslice []float64) {
 
 // Drops NaNs from a slice.
 func DropNan(slice []float64) []float64 {
-
 	res := make([]float64, len(slice))
 	i := 0
 	for _, v := range slice {
@@ -61,19 +60,19 @@ func DropNan(slice []float64) []float64 {
 	}
 	return res[:i]
 }
-// Drops NaNs from a slice in place. This is more memory efficient way than using DropNan.
-// NOTE: Reuses given input slice's memory space so it's not safe to use afterwards.
-func DropNanInplace(slice []float64) []float64 {
 
+// Drops NaNs from a slice in place. This is more memory efficient way than using DropNan.
+func DropNanInplace(slice *[]float64) {
 	i := 0
-	for _, v := range slice {
+	for _, v := range *slice {
 		if IsValid(v) {
-			slice[i] = v
+			(*slice)[i] = v
 			i++
 		}
 	}
-	return slice[:i]
+	*slice = (*slice)[:i]
 }
+
 // Fills NaN values with a value based on given method:
 //  "previous" // fills the NaNs with previous value
 //  "linear"   // fills the NaNs with linear interpolation

--- a/numf/nan_test.go
+++ b/numf/nan_test.go
@@ -27,11 +27,11 @@ func TestNans(t *testing.T) {
 	assert.Equal(t, 0, len(nanslice))
 	nanslice = DropNan(vals)
 	assert.Equal(t, []float64{0, 1, -1}, nanslice)
-
+	DropNanInplace(&vals)
+	assert.Equal(t, []float64{0, 1, -1}, vals)
 }
 
 func TestFillnan(t *testing.T) {
-
 	nan := math.NaN()
 	v := []float64{nan, 0, 1, 2, nan, 4, nan, nan}
 	rprev := []float64{nan, 0, 1, 2, 2, 4, 4, 4}


### PR DESCRIPTION
No need to return anything, uses pointer for cleaning the original array. 